### PR TITLE
Add support for reading the From header

### DIFF
--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -82,3 +82,19 @@ def test_update_missing_file(client):
     response = client.simulate_put(
         '/datasets/{}/files/NEWFILE'.format(ds_id), body=file_data)
     assert response.status == falcon.HTTP_NOT_FOUND
+
+
+def test_add_commit_info(client):
+    ds_id = 'ds000001'
+    file_data = 'Test annotating requests with user info'
+    name = 'Test User'
+    email = 'user@example.com'
+    headers = {
+        'From': '"{}" <{}>'.format(name, email)
+    }
+    response = client.simulate_post(
+        '/datasets/{}/files/USER_ADDED_FILE'.format(ds_id), body=file_data, headers=headers)
+    assert response.status == falcon.HTTP_OK
+    response_content = json.loads(response.content)
+    assert response_content['name'] == name
+    assert response_content['email'] == email


### PR DESCRIPTION
This adds an option From header to file requests, allowing the server to use this to annotate file changes with user commit info if the request is done on behalf of a user.