### PR TITLE
Draft status endpoint and partial flag

### DIFF
--- a/datalad_service/tasks/__init__.py
+++ b/datalad_service/tasks/__init__.py
@@ -1,2 +1,2 @@
 """All Celery tasks and related functions."""
-__all__ = ['dataset', 'files', 'publish']
+__all__ = ['dataset', 'draft', 'files', 'publish']

--- a/datalad_service/tasks/draft.py
+++ b/datalad_service/tasks/draft.py
@@ -1,0 +1,9 @@
+"""Working tree / draft related tasks."""
+from datalad_service.common.celery import dataset_task
+
+
+@dataset_task
+def is_dirty(store, dataset):
+    """Check if a dataset is dirty."""
+    ds = store.get_dataset(dataset)
+    return ds.repo.is_dirty()

--- a/tests/test_draft.py
+++ b/tests/test_draft.py
@@ -20,3 +20,21 @@ def test_add_commit_info(celery_app, client):
     response_content = json.loads(response.content)
     assert response_content['name'] == name
     assert response_content['email'] == email
+
+
+def test_is_dirty(celery_app, client, new_dataset):
+    ds_id = os.path.basename(new_dataset.path)
+    # Check if new_dataset is not dirty
+    response = client.simulate_get(
+        '/datasets/{}/draft'.format(ds_id))
+    assert response.status == falcon.HTTP_OK
+    assert json.loads(response.content)['partial'] == False
+    # Make the dataset dirty
+    response = client.simulate_post(
+        '/datasets/{}/files/NEW_FILE'.format(ds_id), body='some file data')
+    assert response.status == falcon.HTTP_OK
+    # Check if partial state is now true
+    response = client.simulate_get(
+        '/datasets/{}/draft'.format(ds_id))
+    assert response.status == falcon.HTTP_OK
+    assert json.loads(response.content)['partial'] == True


### PR DESCRIPTION
This adds a task and endpoint for getting draft information. The only information returned at the moment is the partial flag, which indicates if the dataset has uncommitted changes in the working tree.

Includes a test for this new endpoint.