### PR TITLE
changes required by snapshot operations

### DIFF
--- a/datalad_service/tasks/validator.py
+++ b/datalad_service/tasks/validator.py
@@ -55,7 +55,8 @@ def issues_mutation(dataset_id, ref, validator_output):
         # Remove extra stats to keep collection size down
         if 'files' in issue:
             for f in issue['files']:
-                del f['file']['stats']
+                if f['file'].get('stats'):
+                    del f['file']['stats']
     issues = {
         'datasetId': dataset_id,
         'id': ref,

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -14,9 +14,9 @@ def test_get_snapshot(client, celery_app):
     result_doc = json.loads(response.content, encoding='utf-8')
 
     assert response.status == falcon.HTTP_OK
-    assert {'files': [{'filename': 'dataset_description.json', 'id': 'MD5E-s97--76dc22875c876b360e7b084fb1219c83.json', 'size': 97}],
-            'tag': SNAPSHOT_ID,
-            'id': '{}:{}'.format(DATASET_ID, SNAPSHOT_ID)} == result_doc
+    assert result_doc['files'] == [{'filename': 'dataset_description.json', 'id': 'MD5E-s97--76dc22875c876b360e7b084fb1219c83.json', 'size': 97}] and \
+            result_doc['tag'] == SNAPSHOT_ID and \
+            result_doc['id'] ==  '{}:{}'.format(DATASET_ID, SNAPSHOT_ID)
 
 
 def test_create_snapshot(client, new_dataset, celery_app):


### PR DESCRIPTION
fixes a small validator bug where issues that had a file list without ['stats'] field were breaking the datalad service. implements delete on the snapshot handler, and returns hexsha on snapshot creation. 