### PR TITLE
Allow s3 migration

### DIFF
--- a/datalad_service/app.py
+++ b/datalad_service/app.py
@@ -5,6 +5,7 @@ from datalad_service.handlers.draft import DraftResource
 from datalad_service.handlers.files import FilesResource
 from datalad_service.handlers.snapshots import SnapshotResource
 from datalad_service.handlers.heartbeat import HeartbeatResource
+from datalad_service.handlers.publish import PublishResource
 
 
 class PathConverter(falcon.routing.converters.BaseConverter):
@@ -24,6 +25,7 @@ def create_app(annex_path):
     datasets = DatasetResource(store)
     dataset_draft = DraftResource(store)
     dataset_files = FilesResource(store)
+    dataset_publish = PublishResource(store)
     dataset_snapshots = SnapshotResource(store)
 
     api.add_route('/heartbeat', heartbeat)
@@ -44,4 +46,7 @@ def create_app(annex_path):
     api.add_route(
         '/datasets/{dataset}/snapshots/{snapshot}/files/{filename:path}', dataset_files)
 
+    api.add_route(
+        '/datasets/{dataset}/publish', dataset_publish
+    )
     return api

--- a/datalad_service/common/s3.py
+++ b/datalad_service/common/s3.py
@@ -65,7 +65,7 @@ def s3_export(dataset, target, treeish='HEAD'):
 
 
 def s3_versions(dataset, realm=DatasetRealm.PRIVATE, snapshot='HEAD'):
-    realm = DatasetRealm.PRIVATE # TODO: FIX WHEN PUBLIC BUCKETS ARE ACTIVATED
+    realm = realm
     dataset_id = os.path.basename(dataset.path)
     bucket_name = '{}'.format(realm.s3_bucket)
 

--- a/datalad_service/common/s3.py
+++ b/datalad_service/common/s3.py
@@ -8,6 +8,12 @@ import datalad_service.config
 class S3ConfigException(Exception):
     pass
 
+def get_s3_realm(realm):
+        if realm == 'PUBLIC':
+            realm = DatasetRealm.PUBLIC
+        else:
+            realm = DatasetRealm.PRIVATE
+        return realm
 
 class DatasetRealm(Enum):
     PRIVATE = 1

--- a/datalad_service/handlers/publish.py
+++ b/datalad_service/handlers/publish.py
@@ -1,0 +1,30 @@
+import falcon
+
+from datalad_service.common.annex import get_from_header
+from datalad_service.common.celery import dataset_queue
+from datalad_service.tasks.dataset import *
+from datalad_service.tasks.publish import migrate_to_bucket
+
+
+class PublishResource(object):
+
+    """A Falcon API wrapper around underlying datalad/git-annex datasets."""
+
+    def __init__(self, store):
+        self.store = store
+
+    def on_post(self, req, resp, dataset):
+        datalad = self.store.get_dataset(dataset)
+        queue = dataset_queue(dataset)
+        publish = migrate_to_bucket.s(self.store.annex_path, dataset)
+        publish.apply_async(queue=queue)
+        resp.media = {}
+        resp.status = falcon.HTTP_OK
+    
+    def on_delete(self, req, resp, dataset):
+        datalad = self.store.get_dataset
+        queue = dataset_queue(dataset)
+        publish = migrate_to_bucket.s(self.store.annex_path, dataset, realm='PRIVATE')
+        publish.apply_async(queue=queue)
+        resp.media = {}
+        resp.status = falcon.HTTP_OK

--- a/datalad_service/handlers/snapshots.py
+++ b/datalad_service/handlers/snapshots.py
@@ -54,7 +54,7 @@ class SnapshotResource(object):
             resp.status = falcon.HTTP_OK
             # Publish after response
             publish = publish_snapshot.s(
-                self.store.annex_path, dataset, snapshot, realm='PRIVATE')
+                self.store.annex_path, dataset, snapshot)
             publish.apply_async(queue=queue)
         else:
             resp.media = {'error': 'tag already exists'}


### PR DESCRIPTION
fixes #2 

allows for users to migrate datasets between public and private s3 remotes