### PR TITLE
Synchronous file access

### DIFF
--- a/datalad_service/app.py
+++ b/datalad_service/app.py
@@ -3,6 +3,7 @@ from datalad_service.datalad import DataladStore
 from datalad_service.handlers.dataset import DatasetResource
 from datalad_service.handlers.draft import DraftResource
 from datalad_service.handlers.files import FilesResource
+from datalad_service.handlers.objects import ObjectsResource
 from datalad_service.handlers.snapshots import SnapshotResource
 from datalad_service.handlers.heartbeat import HeartbeatResource
 from datalad_service.handlers.publish import PublishResource
@@ -25,6 +26,7 @@ def create_app(annex_path):
     datasets = DatasetResource(store)
     dataset_draft = DraftResource(store)
     dataset_files = FilesResource(store)
+    dataset_objects = ObjectsResource(store)
     dataset_publish = PublishResource(store)
     dataset_snapshots = SnapshotResource(store)
 
@@ -37,6 +39,9 @@ def create_app(annex_path):
 
     api.add_route('/datasets/{dataset}/files', dataset_files)
     api.add_route('/datasets/{dataset}/files/{filename:path}', dataset_files)
+
+    api.add_route('/datasets/{dataset}/objects', dataset_objects)
+    api.add_route('/datasets/{dataset}/objects/{filekey:path}', dataset_objects)
 
     api.add_route('/datasets/{dataset}/snapshots', dataset_snapshots)
     api.add_route(

--- a/datalad_service/common/annex.py
+++ b/datalad_service/common/annex.py
@@ -15,6 +15,8 @@ def filter_git_files(files):
 
 
 def get_repo_files(dataset, branch=None):
+    if branch is None:
+        branch = 'HEAD'
     working_files = filter_git_files(dataset.repo.get_files(branch=branch))
     files = []
     for filename in working_files:
@@ -22,11 +24,12 @@ def get_repo_files(dataset, branch=None):
             # Annexed file
             key = dataset.repo.get_file_key(filename)
             size = dataset.repo.get_size_from_key(key)
+            fd = dataset.repo.repo.git.show(branch + ':' + filename)
         except FileInGitError:
             # Regular git file
             key = filename
             size = os.path.getsize(os.path.join(dataset.path, filename))
-        files.append({'filename': filename, 'size': size, 'id': key})
+        files.append({'filename': filename, 'size': size, 'id': key, 'objectpath': fd})
     return files
 
 

--- a/datalad_service/common/annex.py
+++ b/datalad_service/common/annex.py
@@ -23,7 +23,7 @@ def get_repo_files(dataset, branch='HEAD'):
             size = dataset.repo.get_size_from_key(key)
         except FileInGitError:
             # Regular git file
-            key = dataset.repo.commit(branch).tree[filename].hexsha
+            key = dataset.repo.repo.commit(branch).tree[filename].hexsha
             # get file object id here and use as fd
             size = os.path.getsize(os.path.join(dataset.path, filename))
         files.append({'filename': filename, 'size': size, 'id': key})

--- a/datalad_service/common/annex.py
+++ b/datalad_service/common/annex.py
@@ -8,7 +8,6 @@ from datalad.support.exceptions import FileInGitError
 SERVICE_EMAIL = 'git@openneuro.org'
 SERVICE_USER = 'Git Worker'
 
-
 def filter_git_files(files):
     """Remove any git/datalad files from a list of files."""
     return [f for f in files if not (f.startswith('.datalad/') or f == '.gitattributes')]
@@ -22,12 +21,12 @@ def get_repo_files(dataset, branch='HEAD'):
             # Annexed file
             key = dataset.repo.get_file_key(filename)
             size = dataset.repo.get_size_from_key(key)
-            fd = dataset.repo.repo.git.show(branch + ':' + filename)
         except FileInGitError:
             # Regular git file
-            key = filename
+            key = dataset.repo.commit(branch).tree[filename].hexsha
+            # get file object id here and use as fd
             size = os.path.getsize(os.path.join(dataset.path, filename))
-        files.append({'filename': filename, 'size': size, 'id': key, 'objectpath': fd})
+        files.append({'filename': filename, 'size': size, 'id': key})
     return files
 
 

--- a/datalad_service/common/annex.py
+++ b/datalad_service/common/annex.py
@@ -14,9 +14,7 @@ def filter_git_files(files):
     return [f for f in files if not (f.startswith('.datalad/') or f == '.gitattributes')]
 
 
-def get_repo_files(dataset, branch=None):
-    if branch is None:
-        branch = 'HEAD'
+def get_repo_files(dataset, branch='HEAD'):
     working_files = filter_git_files(dataset.repo.get_files(branch=branch))
     files = []
     for filename in working_files:

--- a/datalad_service/handlers/objects.py
+++ b/datalad_service/handlers/objects.py
@@ -1,0 +1,71 @@
+import logging
+import os
+import hashlib
+import struct
+import zlib
+
+import falcon
+
+import git
+from datalad_service.common.annex import get_from_header
+from datalad_service.common.celery import dataset_queue
+from datalad_service.tasks.files import unlock_files, commit_files, get_files, remove_files
+
+
+class ObjectsResource(object):
+    _CHUNK_SIZE_BYTES = 4096
+
+    def __init__(self, store):
+        self.store = store
+        self.logger = logging.getLogger('datalad_service.' + __name__)
+
+    def annex_key_to_path(self, annex_key):
+        word = struct.unpack('<I', hashlib.md5(annex_key).digest()[:4])[0]
+        integer_encoding = [word >> (6 * x) & 31 for x in range(4)]
+        values = ['0123456789zqjxkmvwgpfZQJXKMVWGPF'[x] for x in integer_encoding]
+        return '{}{}/{}{}'.format(values[1], values[0], values[3], values[2])
+
+    @property
+    def annex_path(self):
+        return self.store.annex_path
+
+    def on_get(self, req, resp, dataset, filekey=None):
+        ds_path = self.store.get_dataset_path(dataset)
+        ds = self.store.get_dataset(dataset)
+        if filekey:
+            try:
+                if filekey.startswith('MD5E'):
+                    filepath = '.git/annex/objects/{}/{}/{}'.format(self.annex_key_to_path(filekey), filekey, filekey)
+                    path = '{}/{}'.format(ds_path, filepath)
+                    fd = open(path, 'rb')
+                    resp.stream = fd
+                    resp.stream_len = os.fstat(fd.fileno()).st_size
+                    resp.status = falcon.HTTP_OK
+                else:
+                    dir = filekey[:2]
+                    remaining_hex = filekey[2:]
+                    filepath = '.git/objects/{}/{}'.format(dir, remaining_hex)
+                    path = '{}/{}'.format(ds_path, filepath)
+                    compressed_contents = open(path, 'rb').read()
+                    contents = zlib.decompress(compressed_contents)
+                    resp.body = contents
+                    resp.status = falcon.HTTP_OK
+            except git.exc.GitCommandError:
+                # File is not present in tree
+                resp.media = {'error': 'file not found in git tree'}
+                resp.status = falcon.HTTP_NOT_FOUND
+            except IOError:
+                # File is not kept locally
+                resp.media = {'error': 'file not found'}
+                resp.status = falcon.HTTP_NOT_FOUND
+            except:
+                # Some unknown error
+                resp.media = {
+                    'error': 'an unknown error occurred accessing this file'}
+                resp.status = falcon.HTTP_INTERNAL_SERVER_ERROR
+                self.logger.exception(
+                    'An unknown error processing file with key "{}"'.format(filekey))
+        else:
+            # Filekey was not provided
+            resp.media = {'error': 'no file key was provided'}
+            resp.status = falcon.HTTP_NOT_FOUND

--- a/datalad_service/handlers/objects.py
+++ b/datalad_service/handlers/objects.py
@@ -49,10 +49,6 @@ class ObjectsResource(object):
                     contents = decompressed_contents[decompressed_contents.index(split_char) + len(split_char):]
                     resp.body = contents
                     resp.status = falcon.HTTP_OK
-            except git.exc.GitCommandError:
-                # File is not present in tree
-                resp.media = {'error': 'file not found in git tree'}
-                resp.status = falcon.HTTP_NOT_FOUND
             except IOError:
                 # File is not kept locally
                 resp.media = {'error': 'file not found'}

--- a/datalad_service/handlers/objects.py
+++ b/datalad_service/handlers/objects.py
@@ -7,9 +7,6 @@ import zlib
 import falcon
 
 import git
-from datalad_service.common.annex import get_from_header
-from datalad_service.common.celery import dataset_queue
-from datalad_service.tasks.files import unlock_files, commit_files, get_files, remove_files
 
 
 class ObjectsResource(object):

--- a/datalad_service/tasks/files.py
+++ b/datalad_service/tasks/files.py
@@ -36,7 +36,7 @@ def unlock_files(store, dataset, files):
 
 
 @dataset_task
-def get_files(store, dataset, branch=None):
+def get_files(store, dataset, branch='HEAD'):
     """Get the working tree, optionally a branch tree."""
     ds = store.get_dataset(dataset)
     return get_repo_files(ds, branch)

--- a/tests/dataset_fixtures.py
+++ b/tests/dataset_fixtures.py
@@ -21,6 +21,17 @@ DATASET_DESCRIPTION = {
     'Name': 'Test fixture dataset',
 }
 
+# A list of patterns to avoid annexing in BIDS datasets
+BIDS_NO_ANNEX = [
+    '*.tsv',
+    '*.json',
+    '*.bvec',
+    '*.bval',
+    'README',
+    'CHANGES',
+    '.bidsignore'
+]
+
 
 def id_generator(size=8, chars=string.ascii_uppercase + string.digits):
     return ''.join(random.choice(chars) for _ in range(size))
@@ -47,6 +58,7 @@ def annex_path(tmpdir_factory):
     # Create an empty dataset for testing
     ds = Dataset(ds_path)
     ds.create()
+    ds.no_annex(BIDS_NO_ANNEX)
     json_path = os.path.join(ds_path, 'dataset_description.json')
     with open(json_path, 'w') as f:
         json.dump(DATASET_DESCRIPTION, f, ensure_ascii=False)
@@ -63,6 +75,7 @@ def new_dataset(annex_path):
     ds_path = str(annex_path.join(id_generator()))
     ds = Dataset(ds_path)
     ds.create()
+    ds.no_annex(BIDS_NO_ANNEX)
     json_path = os.path.join(ds_path, 'dataset_description.json')
     dsdesc = {
         'BIDSVersion': '1.0.2',

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -102,7 +102,8 @@ def test_file_indexing(celery_app, client, new_dataset):
     response_content = json.loads(response.content)
     assert response_content['files'] == [
         {'filename': 'LICENSE', 'size': 8,
-            'id': 'MD5E-s8--4d87586dfb83dc4a5d15c6cfa6f61e27'},
+            'id': 'MD5E-s8--4d87586dfb83dc4a5d15c6cfa6f61e27', 
+            'objectpath': '.git/annex/objects/Xz/gq/MD5E-s8--4d87586dfb83dc4a5d15c6cfa6f61e27/MD5E-s8--4d87586dfb83dc4a5d15c6cfa6f61e27'},
         {'filename': 'dataset_description.json', 'size': 101,
             'id': 'MD5E-s101--63ef6d26537d770344904ec51d215d60.json'},
         {'filename': 'sub-01/anat/sub-01_T1w.nii.gz',

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -9,15 +9,8 @@ from .dataset_fixtures import *
 
 def test_get_file(client, celery_app):
     ds_id = 'ds000001'
-    response2 = client.simulate_get('/datasets/{}/files'.format(ds_id))
-    response_content = json.loads(response2.content)
-    assert response_content['files'] == [
-        {'filename': 'dataset_description.json', 'size': 101,
-            'id': 'MD5E-s101--63ef6d26537d770344904ec51d215d60.json', 
-            'objectpath': '.git/annex/objects/p8/GK/MD5E-s101--63ef6d26537d770344904ec51d215d60.json/MD5E-s101--63ef6d26537d770344904ec51d215d60.json'},
-    ]
     result = client.simulate_get(
-        '/datasets/{}/files/.git:annex:objects:p8:GK:MD5E-s101--63ef6d26537d770344904ec51d215d60.json:MD5E-s101--63ef6d26537d770344904ec51d215d60.json'.format(ds_id), file_wrapper=FileWrapper)
+        '/datasets/{}/files/.git:annex:objects:mW:MZ:MD5E-s97--76dc22875c876b360e7b084fb1219c83.json:MD5E-s97--76dc22875c876b360e7b084fb1219c83.json'.format(ds_id), file_wrapper=FileWrapper)
     content_len = int(result.headers['content-length'])
     assert content_len == len(result.content)
     assert json.loads(result.content)['BIDSVersion'] == '1.0.2'

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -10,7 +10,7 @@ from .dataset_fixtures import *
 def test_get_file(client, celery_app):
     ds_id = 'ds000001'
     result = client.simulate_get(
-        '/datasets/{}/files/.git:annex:objects:mW:MZ:MD5E-s97--76dc22875c876b360e7b084fb1219c83.json:MD5E-s97--76dc22875c876b360e7b084fb1219c83.json'.format(ds_id), file_wrapper=FileWrapper)
+        '/datasets/{}/files/dataset_description.json'.format(ds_id), file_wrapper=FileWrapper)
     content_len = int(result.headers['content-length'])
     assert content_len == len(result.content)
     assert json.loads(result.content)['BIDSVersion'] == '1.0.2'
@@ -102,14 +102,13 @@ def test_file_indexing(celery_app, client, new_dataset):
     response = client.simulate_get('/datasets/{}/files'.format(ds_id))
     assert response.status == falcon.HTTP_OK
     response_content = json.loads(response.content)
+    print('response content:', response_content['files'])
+    print('not annexed files:',new_dataset.repo.is_under_annex(['dataset_description.json']))
     assert response_content['files'] == [
         {'filename': 'LICENSE', 'size': 8,
-            'id': 'MD5E-s8--4d87586dfb83dc4a5d15c6cfa6f61e27', 
-            'objectpath': '.git/annex/objects/Xz/gq/MD5E-s8--4d87586dfb83dc4a5d15c6cfa6f61e27/MD5E-s8--4d87586dfb83dc4a5d15c6cfa6f61e27'},
+            'id': 'MD5E-s8--4d87586dfb83dc4a5d15c6cfa6f61e27'},
         {'filename': 'dataset_description.json', 'size': 101,
-            'id': 'MD5E-s101--63ef6d26537d770344904ec51d215d60.json', 
-            'objectpath': '.git/annex/objects/p8/GK/MD5E-s101--63ef6d26537d770344904ec51d215d60.json/MD5E-s101--63ef6d26537d770344904ec51d215d60.json'},
+            'id': '838d19644b3296cf32637bbdf9ae5c87db34842f'},
         {'filename': 'sub-01/anat/sub-01_T1w.nii.gz',
-            'id': 'MD5E-s19--8149926e49b677a5ccecf1ad565acccf.nii.gz', 'size': 19, 
-            'objectpath': '../../.git/annex/objects/5p/Vk/MD5E-s19--8149926e49b677a5ccecf1ad565acccf.nii.gz/MD5E-s19--8149926e49b677a5ccecf1ad565acccf.nii.gz'}
+            'id': 'MD5E-s19--8149926e49b677a5ccecf1ad565acccf.nii.gz', 'size': 19}
     ]

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -10,7 +10,7 @@ from .dataset_fixtures import *
 def test_get_file(client, celery_app):
     ds_id = 'ds000001'
     result = client.simulate_get(
-        '/datasets/{}/files/dataset_description.json'.format(ds_id), file_wrapper=FileWrapper)
+        '/datasets/{}/files/.git:annex:objects:p8:GK:MD5E-s101--63ef6d26537d770344904ec51d215d60.json:MD5E-s101--63ef6d26537d770344904ec51d215d60.json'.format(ds_id), file_wrapper=FileWrapper)
     content_len = int(result.headers['content-length'])
     assert content_len == len(result.content)
     assert json.loads(result.content)['BIDSVersion'] == '1.0.2'
@@ -105,7 +105,8 @@ def test_file_indexing(celery_app, client, new_dataset):
             'id': 'MD5E-s8--4d87586dfb83dc4a5d15c6cfa6f61e27', 
             'objectpath': '.git/annex/objects/Xz/gq/MD5E-s8--4d87586dfb83dc4a5d15c6cfa6f61e27/MD5E-s8--4d87586dfb83dc4a5d15c6cfa6f61e27'},
         {'filename': 'dataset_description.json', 'size': 101,
-            'id': 'MD5E-s101--63ef6d26537d770344904ec51d215d60.json'},
+            'id': 'MD5E-s101--63ef6d26537d770344904ec51d215d60.json', 
+            'objectpath': '.git/annex/objects/p8/GK/MD5E-s101--63ef6d26537d770344904ec51d215d60.json/MD5E-s101--63ef6d26537d770344904ec51d215d60.json'},
         {'filename': 'sub-01/anat/sub-01_T1w.nii.gz',
             'id': 'MD5E-s19--8149926e49b677a5ccecf1ad565acccf.nii.gz', 'size': 19}
     ]

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -9,6 +9,13 @@ from .dataset_fixtures import *
 
 def test_get_file(client, celery_app):
     ds_id = 'ds000001'
+    response2 = client.simulate_get('/datasets/{}/files'.format(ds_id))
+    response_content = json.loads(response2.content)
+    assert response_content['files'] == [
+        {'filename': 'dataset_description.json', 'size': 101,
+            'id': 'MD5E-s101--63ef6d26537d770344904ec51d215d60.json', 
+            'objectpath': '.git/annex/objects/p8/GK/MD5E-s101--63ef6d26537d770344904ec51d215d60.json/MD5E-s101--63ef6d26537d770344904ec51d215d60.json'},
+    ]
     result = client.simulate_get(
         '/datasets/{}/files/.git:annex:objects:p8:GK:MD5E-s101--63ef6d26537d770344904ec51d215d60.json:MD5E-s101--63ef6d26537d770344904ec51d215d60.json'.format(ds_id), file_wrapper=FileWrapper)
     content_len = int(result.headers['content-length'])
@@ -41,8 +48,7 @@ def test_add_file(client, annex_path):
 def test_add_existing_file(client):
     ds_id = 'ds000001'
     file_data = 'should update'
-    response2 = client.simulate_get('/datasets/{}/files'.format(ds_id))
-    print('response2:', response2)
+
     response = client.simulate_post(
         '/datasets/{}/files/dataset_description.json'.format(ds_id), body=file_data)
     

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -41,8 +41,11 @@ def test_add_file(client, annex_path):
 def test_add_existing_file(client):
     ds_id = 'ds000001'
     file_data = 'should update'
+    response2 = client.simulate_get('/datasets/{}/files'.format(ds_id))
+    print('response2:', response2)
     response = client.simulate_post(
         '/datasets/{}/files/dataset_description.json'.format(ds_id), body=file_data)
+    
     assert response.status == falcon.HTTP_OK
 
 
@@ -108,5 +111,6 @@ def test_file_indexing(celery_app, client, new_dataset):
             'id': 'MD5E-s101--63ef6d26537d770344904ec51d215d60.json', 
             'objectpath': '.git/annex/objects/p8/GK/MD5E-s101--63ef6d26537d770344904ec51d215d60.json/MD5E-s101--63ef6d26537d770344904ec51d215d60.json'},
         {'filename': 'sub-01/anat/sub-01_T1w.nii.gz',
-            'id': 'MD5E-s19--8149926e49b677a5ccecf1ad565acccf.nii.gz', 'size': 19}
+            'id': 'MD5E-s19--8149926e49b677a5ccecf1ad565acccf.nii.gz', 'size': 19, 
+            'objectpath': '../../.git/annex/objects/5p/Vk/MD5E-s19--8149926e49b677a5ccecf1ad565acccf.nii.gz/MD5E-s19--8149926e49b677a5ccecf1ad565acccf.nii.gz'}
     ]

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -12,7 +12,6 @@ def test_get_git_object(client, celery_app):
     result = client.simulate_get(
         '/datasets/{}/objects/85b9ddf2bfaf1d9300d612dc29774a98cc1d5e25'.format(ds_id), file_wrapper=FileWrapper)
     content_len = int(result.headers['content-length'])
-    print(result.content)
     assert content_len == len(result.content)
     assert json.loads(result.content)['BIDSVersion'] == '1.0.2'
 
@@ -21,5 +20,18 @@ def test_get_annexed_object(client, celery_app):
     result = client.simulate_get(
         '/datasets/{}/objects/MD5E-s19--8149926e49b677a5ccecf1ad565acccf.nii.gz'.format(ds_id), file_wrapper=FileWrapper)
     content_len = int(result.headers['content-length'])
-    print(result)
     assert content_len == len(result.content)
+
+def test_no_object_provided(client, celery_app):
+    ds_id = 'ds000001'
+    result = client.simulate_get(
+        '/datasets/{}/objects/'.format(ds_id)
+    )
+    assert result.content == b'{"error": "no file key was provided"}'
+
+def test_object_doesnt_exist(client, celery_app):
+    ds_id = 'ds000001'
+    result = client.simulate_get(
+        '/datasets/{}/objects/this_doesnt_exist'.format(ds_id)
+    )
+    assert result.content == b'{"error": "file not found"}'

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -1,0 +1,25 @@
+import falcon
+from falcon import testing
+import json
+import pytest
+from datalad.api import Dataset
+
+from .dataset_fixtures import *
+
+
+def test_get_git_object(client, celery_app):
+    ds_id = 'ds000001'
+    result = client.simulate_get(
+        '/datasets/{}/objects/85b9ddf2bfaf1d9300d612dc29774a98cc1d5e25'.format(ds_id), file_wrapper=FileWrapper)
+    content_len = int(result.headers['content-length'])
+    print(result.content)
+    assert content_len == len(result.content)
+    assert json.loads(result.content)['BIDSVersion'] == '1.0.2'
+
+def test_get_annexed_object(client, celery_app):
+    ds_id = 'ds000001'
+    result = client.simulate_get(
+        '/datasets/{}/objects/MD5E-s19--8149926e49b677a5ccecf1ad565acccf.nii.gz'.format(ds_id), file_wrapper=FileWrapper)
+    content_len = int(result.headers['content-length'])
+    print(result)
+    assert content_len == len(result.content)

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -14,7 +14,7 @@ def test_get_snapshot(client, celery_app):
     result_doc = json.loads(response.content, encoding='utf-8')
 
     assert response.status == falcon.HTTP_OK
-    assert result_doc['files'] == [{'filename': 'dataset_description.json', 'id': 'MD5E-s97--76dc22875c876b360e7b084fb1219c83.json', 'size': 97}] and \
+    assert result_doc['files'] == [{'filename': 'dataset_description.json', 'id': 'MD5E-s97--76dc22875c876b360e7b084fb1219c83.json', 'size': 97, 'objectpath': '.git/annex/objects/mW/MZ/MD5E-s97--76dc22875c876b360e7b084fb1219c83.json/MD5E-s97--76dc22875c876b360e7b084fb1219c83.json'}] and \
             result_doc['tag'] == SNAPSHOT_ID and \
             result_doc['id'] ==  '{}:{}'.format(DATASET_ID, SNAPSHOT_ID)
 

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -14,7 +14,7 @@ def test_get_snapshot(client, celery_app):
     result_doc = json.loads(response.content, encoding='utf-8')
 
     assert response.status == falcon.HTTP_OK
-    assert result_doc['files'] == [{'filename': 'dataset_description.json', 'id': 'MD5E-s97--76dc22875c876b360e7b084fb1219c83.json', 'size': 97, 'objectpath': '.git/annex/objects/mW/MZ/MD5E-s97--76dc22875c876b360e7b084fb1219c83.json/MD5E-s97--76dc22875c876b360e7b084fb1219c83.json'}] and \
+    assert result_doc['files'] == [{'filename': 'dataset_description.json', 'id': '85b9ddf2bfaf1d9300d612dc29774a98cc1d5e25', 'size': 97}] and \
             result_doc['tag'] == SNAPSHOT_ID and \
             result_doc['id'] ==  '{}:{}'.format(DATASET_ID, SNAPSHOT_ID)
 


### PR DESCRIPTION
* adds the hash string for the local git object or the md5 hash for annexed files to response of get_repo_files() as the 'id'
* expects this object path as the input to on_get handler of objects.py, which accesses filepath synchronously rather than using the celery queue
* testing for objects endpoint implemented, and file tests fixed to handle new id formats