### PR TITLE
Fix tag request conflicts (move to celery worker).

### DIFF
--- a/datalad_service/tasks/__init__.py
+++ b/datalad_service/tasks/__init__.py
@@ -1,2 +1,2 @@
 """All Celery tasks and related functions."""
-__all__ = ['dataset', 'draft', 'files', 'publish']
+__all__ = ['dataset', 'draft', 'files', 'publish', 'snapshots']

--- a/datalad_service/tasks/snapshots.py
+++ b/datalad_service/tasks/snapshots.py
@@ -1,0 +1,11 @@
+from datalad_service.common.celery import dataset_task
+
+
+@dataset_task
+def get_snapshots(store, dataset):
+    ds = store.get_dataset(dataset)
+    repo_tags = ds.repo.get_tags()
+    # Include an extra id field to uniquely identify snapshots
+    tags = [{'id': '{}:{}'.format(dataset, tag['name']), 'tag': tag['name'], 'hexsha': tag['hexsha']}
+            for tag in repo_tags]
+    return tags


### PR DESCRIPTION
This fixes a rare deadlock where several requests for a datasets tags could get stuck waiting on each other.