### PR TITLE
Dependency updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
       - run: sudo apt-get update && sudo apt-get install build-essential redis-server
 
       # install yarn for bids-validator
-      - run: curl -o- -L https://yarnpkg.com/install.sh | sudo bash -s -- --version 1.6.0
+      - run: curl -o- -L https://yarnpkg.com/install.sh | sudo bash -s -- --version 1.9.2
 
       # create venv and install dependencies
       - run:

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ cffi==1.11.5
 chardet==3.0.4
 citeproc-py==0.4.0
 coverage==4.5.1
-cryptography==2.2.2
+cryptography==2.3
 datalad==0.10.1
 dnspython==1.15.0
 docutils==0.14


### PR DESCRIPTION
Fix the CI build yarn install and updates cryptography dep to 2.3 due to a security release.