### PR TITLE
Don't force a checkout to retrieve files during snapshot creation

### DIFF
--- a/datalad_service/common/annex.py
+++ b/datalad_service/common/annex.py
@@ -20,6 +20,7 @@ def get_repo_files(dataset, branch=None):
         branch = None
     working_files = filter_git_files(dataset.repo.get_files(branch=branch))
     files = []
+    tree = dataset.repo.repo.commit(branch).tree
     for filename in working_files:
         try:
             # Annexed file
@@ -27,7 +28,7 @@ def get_repo_files(dataset, branch=None):
             size = dataset.repo.get_size_from_key(key)
         except (FileInGitError, FileNotInAnnexError):
             # Regular git file
-            key = dataset.repo.repo.commit(branch).tree[filename].hexsha
+            key = tree[filename].hexsha
             # get file object id here and use as fd
             size = os.path.getsize(os.path.join(dataset.path, filename))
         files.append({'filename': filename, 'size': size, 'id': key})

--- a/datalad_service/handlers/snapshots.py
+++ b/datalad_service/handlers/snapshots.py
@@ -46,10 +46,9 @@ class SnapshotResource(object):
         queue = dataset_queue(dataset)
         create = create_snapshot.si(
             self.store.annex_path, dataset, snapshot).set(queue=queue)
-        get = get_files.si(self.store.annex_path, dataset,
-                           branch=snapshot).set(queue=queue)
+        # We don't need to include the branch in get_files, it is inherent in snapshot_creation
+        get = get_files.si(self.store.annex_path, dataset).set(queue=queue)
         created = chain(create, get)()
-        # created.wait()
         if not created.failed():
             resp.media = self._get_snapshot(dataset, snapshot, created.get())
             resp.status = falcon.HTTP_OK


### PR DESCRIPTION
This is a little less robust but much faster.