### PR TITLE
Add support for logging errors to sentry

### DIFF
--- a/datalad_service/app.py
+++ b/datalad_service/app.py
@@ -1,4 +1,6 @@
 import falcon
+
+from datalad_service.common import raven
 from datalad_service.datalad import DataladStore
 from datalad_service.handlers.dataset import DatasetResource
 from datalad_service.handlers.draft import DraftResource
@@ -18,8 +20,12 @@ class PathConverter(falcon.routing.converters.BaseConverter):
 
 
 def create_app(annex_path):
+    raven.setup()
+
     api = application = falcon.API(middleware=AuthenticateMiddleware())
     api.router_options.converters['path'] = PathConverter
+
+    raven.falcon_handler(api)
 
     store = DataladStore(annex_path)
 
@@ -42,7 +48,8 @@ def create_app(annex_path):
     api.add_route('/datasets/{dataset}/files/{filename:path}', dataset_files)
 
     api.add_route('/datasets/{dataset}/objects', dataset_objects)
-    api.add_route('/datasets/{dataset}/objects/{filekey:path}', dataset_objects)
+    api.add_route(
+        '/datasets/{dataset}/objects/{filekey:path}', dataset_objects)
 
     api.add_route('/datasets/{dataset}/snapshots', dataset_snapshots)
     api.add_route(

--- a/datalad_service/common/raven.py
+++ b/datalad_service/common/raven.py
@@ -1,0 +1,47 @@
+import falcon
+import raven
+
+import datalad_service.config
+
+
+client = None
+
+
+def setup():
+    """If configured, enables a Sentry client."""
+    global client
+    if datalad_service.config.SENTRY_DSN:
+        client = raven.Client(datalad_service.config.SENTRY_DSN)
+
+
+def falcon_handler(api):
+    """Registers a general Exception logger for Falcon requests."""
+    # This function comes from https://github.com/falconry/falcon/issues/266#issuecomment-206300970
+    def internal_error_handler(ex, req, resp, params):
+        data = {
+            'request': {
+                'url': req.url,
+                'method': req.method,
+                'query_string': req.query_string,
+                'env': req.env,
+                'data': req.params,
+                'headers': req.headers,
+            }
+        }
+        message = isinstance(ex, falcon.HTTPError) and ex.title or str(ex)
+        ident = client.captureException(message=message, data=data)
+
+        if not isinstance(ex, falcon.HTTPError):
+            resp.status = falcon.HTTP_500
+            resp.body = ('A server error occurred (reference code: "%s"). '
+                         'Please contact the administrator.' % ident)
+        else:
+            raise ex
+
+    api.add_error_handler(Exception, internal_error_handler)
+
+
+def set_user_context(user):
+    """If configured, set user info on errors."""
+    if client:
+        client.user_context(user)

--- a/datalad_service/config.py
+++ b/datalad_service/config.py
@@ -24,3 +24,6 @@ AWS_ACCOUNT_ID = get_environ('AWS_ACCOUNT_ID')
 AWS_S3_PRIVATE_BUCKET = get_environ('AWS_S3_PRIVATE_BUCKET')
 AWS_S3_PUBLIC_BUCKET = get_environ('AWS_S3_PUBLIC_BUCKET')
 JWT_SECRET=get_environ('JWT_SECRET')
+
+# Sentry monitoring
+SENTRY_DSN = get_environ('SENTRY_DSN')

--- a/datalad_service/middleware/auth.py
+++ b/datalad_service/middleware/auth.py
@@ -1,6 +1,9 @@
 import jwt
 import os
 
+from datalad_service.common.raven import set_user_context
+
+
 class AuthenticateMiddleware(object):
     def process_request(self, req, resp):
         """Process the request before routing it.
@@ -14,6 +17,11 @@ class AuthenticateMiddleware(object):
         cookies = req.cookies
         if 'accessToken' in cookies:
             try:
-                req.context['user'] = jwt.decode(cookies['accessToken'], key=os.environ['JWT_SECRET'])
+                req.context['user'] = jwt.decode(
+                    cookies['accessToken'], key=os.environ['JWT_SECRET'])
+                set_user_context(req.context['user'])
             except:
                 req.context['user'] = None
+                set_user_context(None)
+        else:
+            set_user_context(None)

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,6 +61,7 @@ pytest-cov==2.5.1
 python-dateutil==2.7.3
 python-mimeparse==1.6.0
 pytz==2018.4
+raven==6.9.0
 redis==2.10.6
 requests==2.18.4
 s3transfer==0.1.13


### PR DESCRIPTION
This logs any exceptions within a Falcon request to Sentry. Will help track down issues that occur across domains (openneuro-server + datalad-service ones, for example).

:bird:²