### PR TITLE
Avoid loading the dataset on every object get

### DIFF
--- a/datalad_service/handlers/objects.py
+++ b/datalad_service/handlers/objects.py
@@ -28,7 +28,6 @@ class ObjectsResource(object):
 
     def on_get(self, req, resp, dataset, filekey=None):
         ds_path = self.store.get_dataset_path(dataset)
-        ds = self.store.get_dataset(dataset)
         if filekey:
             try:
                 if filekey.startswith('MD5E'):


### PR DESCRIPTION
Looks like this is just a relic of an older version.