### PR TITLE
Publish to S3 and GitHub in a dedicated worker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ COPY package.json /package.json
 COPY requirements.txt /requirements.txt
 COPY datalad_service /datalad_service
 COPY dataset-worker /dataset-worker
+COPY publish-worker /publish-worker
 COPY get_docker_scale.py /get_docker_scale.py
 COPY ./ssh_config /root/.ssh/config
 

--- a/datalad_service/common/celery.py
+++ b/datalad_service/common/celery.py
@@ -15,6 +15,10 @@ def dataset_queue(dataset):
     return 'dataset-worker-{}'.format(dataset_hash(dataset))
 
 
+def publish_queue():
+    return 'publish-worker'
+
+
 def dataset_hash(key):
     """Return which worker for a given task."""
     return hash(key) % DATALAD_WORKERS + 1

--- a/datalad_service/common/s3.py
+++ b/datalad_service/common/s3.py
@@ -79,10 +79,8 @@ def s3_export(dataset, target, treeish='HEAD'):
     )
 
 
-def s3_versions(dataset, realm=DatasetRealm.PRIVATE, snapshot='HEAD'):
-    realm = realm
+def s3_versions(dataset, bucket_name, snapshot='HEAD'):
     dataset_id = os.path.basename(dataset.path)
-    bucket_name = '{}'.format(realm.s3_bucket)
 
     # get s3 bucket
     s3 = boto3.resource('s3')
@@ -105,7 +103,6 @@ def s3_versions(dataset, realm=DatasetRealm.PRIVATE, snapshot='HEAD'):
                 'filename': key.split(dataset_id + '/')[-1],
                 'urls': [url.format(bucket_name, key, version), rel.format(dataset_id, snapshot, filename.replace('/', ':'))]
             })
-    except:
+    finally:
         return versions
-    
-    return versions
+

--- a/publish-worker
+++ b/publish-worker
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo "Publish worker starting..."
+celery -A datalad_service.worker worker -Q publish-worker -l info -c 4


### PR DESCRIPTION
This adds a new Celery worker dedicated to running the i/o blocking remote publish tasks for Github and S3. These tasks are started from the existing publish task to make sure they are still executed in order but once this step in the dataset queue is reached, these can run asynchronously and only briefly hold a lock delaying other git operations.