### PR TITLE
The snapshot handler must wait for the snapshot in order to return metadata

### DIFF
--- a/datalad_service/handlers/snapshots.py
+++ b/datalad_service/handlers/snapshots.py
@@ -49,6 +49,7 @@ class SnapshotResource(object):
         create = create_snapshot.si(
             self.store.annex_path, dataset, snapshot).set(queue=queue)
         created = create.apply_async()
+        created.wait()
         if not created.failed():
             resp.media = self._get_snapshot(dataset, snapshot)
             resp.status = falcon.HTTP_OK


### PR DESCRIPTION
This race condition was leading to failed snapshot creation sometimes.