### PR TITLE
Move get_snapshot out to the Celery workers

### DIFF
--- a/datalad_service/tasks/snapshots.py
+++ b/datalad_service/tasks/snapshots.py
@@ -2,6 +2,14 @@ from datalad_service.common.celery import dataset_task
 
 
 @dataset_task
+def get_snapshot(store, dataset, snapshot):
+    # Get metadata for a snapshot (hexsha)
+    ds = store.get_dataset(dataset)
+    hexsha = ds.repo.repo.commit(snapshot).hexsha
+    return {'id': '{}:{}'.format(dataset, snapshot), 'tag': snapshot, 'hexsha': hexsha}
+
+
+@dataset_task
 def get_snapshots(store, dataset):
     ds = store.get_dataset(dataset)
     repo_tags = ds.repo.get_tags()


### PR DESCRIPTION
This is less efficient but avoids blocking the gunicorn workers as much, improving reliability.