### PR TITLE
Optimize get_repo_files for many files

### DIFF
--- a/datalad_service/common/annex.py
+++ b/datalad_service/common/annex.py
@@ -31,7 +31,7 @@ def compute_git_hash(path, size):
     git_obj_header = 'blob {}'.format(size).encode() + b'\x00'
     with open(path, 'r+b') as fd:
         # Maybe we don't need mmap here?
-        # It profiles marginally faster with large json files
+        # It profiles marginally faster with contrived large files
         with mmap(fd.fileno(), 0) as mm:
             blob_hash = hashlib.sha1()
             blob_hash.update(git_obj_header)
@@ -44,7 +44,7 @@ def get_repo_files(dataset, branch=None):
     if branch == None or branch == 'HEAD' or branch == dataset.repo.get_active_branch():
         files = []
         for dirpath, dirnames, filenames in os.walk(dataset.path, topdown=True):
-            # Filter out the '.'git' and '.datalad' dirs
+            # Filter out the '.git' and '.datalad' dirs
             # topdown=True lets us do this during the loop
             dirnames[:] = [d for d in dirnames if not (d == '.git' or d == '.datalad')]
             for f_name in filenames:

--- a/datalad_service/common/annex.py
+++ b/datalad_service/common/annex.py
@@ -1,5 +1,8 @@
+import hashlib
+from mmap import mmap
 import os
 import re
+import stat
 
 from datalad.config import ConfigManager
 from datalad.support.exceptions import FileInGitError, FileNotInAnnexError
@@ -22,19 +25,54 @@ def create_file_obj(dataset, tree, file_key):
             'id': key}
 
 
+def compute_git_hash(path, size):
+    git_obj_header = 'blob {}'.format(size).encode() + b'\x00'
+    with open(path, 'r+b') as fd:
+        with mmap(fd.fileno(), 0) as mm:
+            blob_hash = hashlib.sha1()
+            blob_hash.update(git_obj_header)
+            blob_hash.update(mm)
+            return blob_hash.hexdigest()
+
+
 def get_repo_files(dataset, branch=None):
     # If we're on the right branch, use the fast path with branch=None
-    if branch == 'HEAD' or branch == dataset.repo.get_active_branch():
-        branch = None
-    working_files = dataset.repo.get_files(branch=branch)
-    # Do the tree lookup only once
-    tree = dataset.repo.repo.commit(branch).tree
-    # Zip up array of (filename, key) tuples
-    file_keys = zip(working_files, dataset.repo.get_file_key(working_files))
-    # Produce JSON results and lookup any missing non-annex file sizes
-    files = [create_file_obj(dataset, tree, file_key)
-             for file_key in file_keys if not (file_key[0].startswith('.datalad/') or file_key[0] == '.gitattributes')]
-    return files
+    if branch == None or branch == 'HEAD' or branch == dataset.repo.get_active_branch():
+        files = []
+        for dirpath, dirnames, filenames in os.walk(dataset.path, topdown=True):
+            dirnames[:] = [d for d in dirnames if not (d == '.git' or d == '.datalad')]
+            for f_name in filenames:
+                if f_name == '.gitattributes':
+                    continue
+                f_path = os.path.join(dirpath, f_name)
+                rel_path = os.path.relpath(f_path, dataset.path)
+                f_stat = os.lstat(f_path)
+                if stat.S_ISLNK(f_stat.st_mode):
+                    # Annexed file
+                    l_path = os.readlink(f_path)
+                    key = l_path.split('/')[-1]
+                    # Get the size from key
+                    size = int(key.split('-', 2)[1].lstrip('s'))
+                    files.append({'filename': rel_path, 'size': size, 'id': key})
+                else:
+                    # Regular git file
+                    size = f_stat.st_size
+                    # Compute git hash
+                    blob_hash = compute_git_hash(f_path, size)
+                    files.append({'filename': rel_path, 'size': size,
+                                  'id': blob_hash})
+        return files
+    else:
+        working_files = dataset.repo.get_files(branch=branch)
+        # Do the tree lookup only once
+        tree = dataset.repo.repo.commit(branch).tree
+        # Zip up array of (filename, key) tuples
+        file_keys = zip(
+            working_files, dataset.repo.get_file_key(working_files))
+        # Produce JSON results and lookup any missing non-annex file sizes
+        files = [create_file_obj(dataset, tree, file_key)
+                 for file_key in file_keys if not (file_key[0].startswith('.datalad/') or file_key[0] == '.gitattributes')]
+        return files
 
 
 class CommitInfo():

--- a/tests/profile_get_files.py
+++ b/tests/profile_get_files.py
@@ -1,0 +1,25 @@
+import os
+
+from datalad.api import Dataset
+from datalad_service.common.annex import get_repo_files
+import vmprof
+
+from .dataset_fixtures import *
+
+
+def test_profile_get_repo_files(annex_path, new_dataset):
+    ds_id = os.path.basename(new_dataset.path)
+    ds = Dataset(str(annex_path.join(ds_id)))
+    for each in range(5000):
+        filename = 'file-{}'.format(each)
+        path = os.path.join(new_dataset.path, filename)
+        with open(path, 'a'):
+            os.utime(path)
+    # Add all generated files
+    ds.add('.')
+    # Profile get_repo_files by itself
+    with open('{}.prof'.format(__name__), 'w+b') as fd:
+        vmprof.enable(fd.fileno())
+        for n in range(1):
+            get_repo_files(ds)
+        vmprof.disable()

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -106,10 +106,10 @@ def test_file_indexing(celery_app, client, new_dataset):
     print('not annexed files:', new_dataset.repo.is_under_annex(
         ['dataset_description.json']))
     assert response_content['files'] == [
-        {'filename': 'LICENSE', 'size': 8,
-            'id': 'MD5E-s8--4d87586dfb83dc4a5d15c6cfa6f61e27'},
         {'filename': 'dataset_description.json', 'size': 101,
             'id': '838d19644b3296cf32637bbdf9ae5c87db34842f'},
+        {'filename': 'LICENSE', 'size': 8,
+         'id': 'MD5E-s8--4d87586dfb83dc4a5d15c6cfa6f61e27'},
         {'filename': 'sub-01/anat/sub-01_T1w.nii.gz',
             'id': 'MD5E-s19--8149926e49b677a5ccecf1ad565acccf.nii.gz', 'size': 19}
     ]


### PR DESCRIPTION
This is another optimization for get_repo_files to allow it to handle the case where draft edits are made with 100k files.