### PR TITLE
Add test for zero length files and handle this case correctly when calculating git hash

### DIFF
--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -105,14 +105,14 @@ def test_file_indexing(celery_app, client, new_dataset):
     print('response content:', response_content['files'])
     print('not annexed files:', new_dataset.repo.is_under_annex(
         ['dataset_description.json']))
-    assert response_content['files'] == [
+    assert all(f in response_content['files'] for f in [
         {'filename': 'dataset_description.json', 'size': 101,
             'id': '838d19644b3296cf32637bbdf9ae5c87db34842f'},
         {'filename': 'LICENSE', 'size': 8,
-         'id': 'MD5E-s8--4d87586dfb83dc4a5d15c6cfa6f61e27'},
+            'id': 'MD5E-s8--4d87586dfb83dc4a5d15c6cfa6f61e27'},
         {'filename': 'sub-01/anat/sub-01_T1w.nii.gz',
             'id': 'MD5E-s19--8149926e49b677a5ccecf1ad565acccf.nii.gz', 'size': 19}
-    ]
+    ])
 
 
 def test_empty_file(celery_app, client, new_dataset):
@@ -126,8 +126,13 @@ def test_empty_file(celery_app, client, new_dataset):
     response = client.simulate_get('/datasets/{}/files'.format(ds_id))
     assert response.status == falcon.HTTP_OK
     response_content = json.loads(response.content)
-    assert response_content['files'] == [{'filename': 'dataset_description.json', 'id': '838d19644b3296cf32637bbdf9ae5c87db34842f', 'size': 101}, {
-        'filename': 'LICENSE', 'id': 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391', 'size': 0}]
+    # Check that all elements exist in both lists
+    assert all(f in response_content['files'] for f in [
+        {'filename': 'dataset_description.json',
+            'id': '838d19644b3296cf32637bbdf9ae5c87db34842f', 'size': 101},
+        {'filename': 'LICENSE',
+            'id': 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391', 'size': 0}
+    ])
 
 
 def test_untracked_file_index(celery_app, client, new_dataset):

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -115,6 +115,21 @@ def test_file_indexing(celery_app, client, new_dataset):
     ]
 
 
+def test_empty_file(celery_app, client, new_dataset):
+    """Catch any regressions for 0 length files."""
+    ds_id = os.path.basename(new_dataset.path)
+    # Post an empty file
+    response = client.simulate_post(
+        '/datasets/{}/files/LICENSE'.format(ds_id), body='')
+    assert response.status == falcon.HTTP_OK
+    # Get the files in the committed tree
+    response = client.simulate_get('/datasets/{}/files'.format(ds_id))
+    assert response.status == falcon.HTTP_OK
+    response_content = json.loads(response.content)
+    assert response_content['files'] == [{'filename': 'dataset_description.json', 'id': '838d19644b3296cf32637bbdf9ae5c87db34842f', 'size': 101}, {
+        'filename': 'LICENSE', 'id': 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391', 'size': 0}]
+
+
 def test_untracked_file_index(celery_app, client, new_dataset):
     ds_id = os.path.basename(new_dataset.path)
     # Post test file


### PR DESCRIPTION
This tests and resolves a regression caused by the optimization to get_repo_files.