### PR TITLE
Fixups for S3 remotes configuration

### DIFF
--- a/datalad_service/common/s3.py
+++ b/datalad_service/common/s3.py
@@ -44,27 +44,30 @@ class DatasetRealm(Enum):
 def setup_s3_sibling(dataset, realm):
     """Add a sibling for an S3 bucket publish."""
     dataset_id = os.path.basename(dataset.path)
+    annex_options = [
+        realm.s3_remote,
+        'type=S3',
+        'bucket={}'.format(realm.s3_bucket),
+        'exporttree=yes',
+        'partsize=1GiB',
+        'encryption=none',
+        'fileprefix={}/'.format(dataset_id),
 
-    if (realm == DatasetRealm.PUBLIC):
+    ]
+    if realm == DatasetRealm.PUBLIC:
         public = getattr(datalad_service.config, 'DATALAD_S3_PUBLIC_ON_EXPORT')
+        if public == 'yes':
+            annex_options += [
+                'autoenable=true',
+                'publicurl=http://{}.s3.amazonaws.com/'.format(realm.s3_bucket),
+            ]
     else:
         public = 'no'
 
+    annex_options.append('public={}'.format(public))
+
     # TODO - There may be a better way to do this?
-    dataset.repo._run_annex_command(
-        'initremote',
-        annex_options=[
-            realm.s3_remote,
-            'type=S3',
-            'bucket={}'.format(realm.s3_bucket),
-            'exporttree=yes',
-            'partsize=1GiB',
-            'encryption=none',
-            'fileprefix={}/'.format(dataset_id),
-            'public={}'.format(public),
-            'publicurl={}'.format(public),
-            'autoenable=true'
-        ])
+    dataset.repo._run_annex_command('initremote', annex_options=annex_options)
 
 
 def s3_export(dataset, target, treeish='HEAD'):

--- a/datalad_service/common/s3.py
+++ b/datalad_service/common/s3.py
@@ -45,14 +45,12 @@ def setup_s3_sibling(dataset, realm):
     """Add a sibling for an S3 bucket publish."""
     dataset_id = os.path.basename(dataset.path)
     annex_options = [
-        realm.s3_remote,
         'type=S3',
         'bucket={}'.format(realm.s3_bucket),
         'exporttree=yes',
         'partsize=1GiB',
         'encryption=none',
         'fileprefix={}/'.format(dataset_id),
-
     ]
     if realm == DatasetRealm.PUBLIC:
         public = getattr(datalad_service.config, 'DATALAD_S3_PUBLIC_ON_EXPORT')
@@ -66,8 +64,7 @@ def setup_s3_sibling(dataset, realm):
 
     annex_options.append('public={}'.format(public))
 
-    # TODO - There may be a better way to do this?
-    dataset.repo._run_annex_command('initremote', annex_options=annex_options)
+    dataset.repo.init_remote(realm.s3_remote, options=annex_options)
 
 
 def s3_export(dataset, target, treeish='HEAD'):


### PR DESCRIPTION
- [x] do not `autoenable` s3-PRIVATE  (Closes #66)
- [x] provide correct publicurl for public bucket (only) (Partially addresses #67). 
     - [ ] In addition to this fix, you would need to adjust the url in already existing repositories (`git annex enableremote s3-PUBLIC publicurl=http://openneuro.org.s3.amazonaws.com/`)
     - I am not sure if this is the optimal URL for the bucket to be used somehow. AWS supports [two styles and allows to specify the region](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html#access-bucket-intro).  But I think this should be good enough if not optimal
- [x] avoid direct calling of protected helper method, use `AnnexRepo.init_remote`
- [ ] test somehow... apparently it is at least smoke tested but not for public access setup.
