### PR TITLE
Add 'versioning=yes' to s3 remotes

### DIFF
--- a/datalad_service/common/s3.py
+++ b/datalad_service/common/s3.py
@@ -48,6 +48,7 @@ def setup_s3_sibling(dataset, realm):
         'type=S3',
         'bucket={}'.format(realm.s3_bucket),
         'exporttree=yes',
+        'versioning=yes',
         'partsize=1GiB',
         'encryption=none',
         'fileprefix={}/'.format(dataset_id),


### PR DESCRIPTION
This will enable tracking object versions for the S3 remotes.