### PR TITLE
Fix crash when obtaining the size of files only in ancestor commits.

### DIFF
--- a/datalad_service/common/annex.py
+++ b/datalad_service/common/annex.py
@@ -23,7 +23,7 @@ def create_file_obj(dataset, tree, file_key):
     # Regular
     if not key:
         key = tree[filename].hexsha
-        size = os.path.getsize(file_path)
+        size = tree[filename].size
     file_id = compute_file_hash(key, rel_path)
     return {'filename': filename,
             'size': size,

--- a/tests/test_annex.py
+++ b/tests/test_annex.py
@@ -1,8 +1,3 @@
-import json
-
-import falcon
-import pytest
-
 from .dataset_fixtures import *
 from datalad_service.common.annex import create_file_obj
 

--- a/tests/test_annex.py
+++ b/tests/test_annex.py
@@ -1,0 +1,29 @@
+import json
+
+import falcon
+import pytest
+
+from .dataset_fixtures import *
+from datalad_service.common.annex import create_file_obj
+
+expected_file_object = {
+    'filename': 'dataset_description.json',
+    'id': '43502da40903d08b18b533f8897330badd6e1da3',
+    'key': '838d19644b3296cf32637bbdf9ae5c87db34842f',
+    'size': 101
+}
+
+
+def test_create_file_obj_unannexed(new_dataset):
+    tree = new_dataset.repo.repo.commit('HEAD').tree
+    assert create_file_obj(
+        new_dataset, tree, ('dataset_description.json', None)) == expected_file_object
+
+
+def test_create_file_obj_deleted(new_dataset):
+    """Test for the case where this file only exists in ancestor commits"""
+    hexsha = new_dataset.repo.repo.head.commit
+    new_dataset.remove('dataset_description.json')
+    tree = new_dataset.repo.repo.commit(hexsha).tree
+    assert create_file_obj(
+        new_dataset, tree, ('dataset_description.json', None)) == expected_file_object


### PR DESCRIPTION
os.path.getsize will fail if the file is missing from HEAD, instead we need to get the size from the git object. Adds a unit test for this situation.

This fixes https://github.com/OpenNeuroOrg/openneuro/issues/1014 and https://github.com/OpenNeuroOrg/openneuro/issues/1013