### PR TITLE
create_snapshot should call update_description inline

### DIFF
--- a/datalad_service/tasks/dataset.py
+++ b/datalad_service/tasks/dataset.py
@@ -77,7 +77,7 @@ def create_snapshot(store, dataset, snapshot, description_fields={}):
     tagged = [tag for tag in ds.repo.get_tags() if tag['name'] == snapshot]
     if not tagged:
         queue = dataset_queue(dataset)
-        updated = update_description.apply_async(
+        updated = update_description.apply(
             queue=queue, args=(store.annex_path, dataset, description_fields))
         updated.wait()
         if not updated.failed():


### PR DESCRIPTION
Ran into an exception creating a snapshot on master and this looks to be the issue. Tasks can't wait on other tasks since it would lead to obvious deadlocks.