### PR TITLE
Use the same JSON indent rules as OpenNeuro

### DIFF
--- a/datalad_service/tasks/description.py
+++ b/datalad_service/tasks/description.py
@@ -2,10 +2,12 @@ import json
 import os
 from datalad_service.common.celery import dataset_task
 
+
 def edit_description(description, new_fields):
     updated = description.copy()
     updated.update(new_fields)
     return updated
+
 
 @dataset_task
 def update_description(store, dataset, description_fields):
@@ -13,9 +15,10 @@ def update_description(store, dataset, description_fields):
     description = ds.repo.repo.git.show(
         'HEAD:dataset_description.json')
     description_json = json.loads(description)
-    if any (description_fields):
+    if any(description_fields):
         updated = edit_description(description_json, description_fields)
-        path = os.path.join(store.get_dataset_path(dataset), 'dataset_description.json')
+        path = os.path.join(store.get_dataset_path(
+            dataset), 'dataset_description.json')
         with open(path, 'r+', encoding='utf-8') as description_file:
             description_file_contents = description_file.read()
             if description_file_contents[-1] == '\n':
@@ -24,7 +27,7 @@ def update_description(store, dataset, description_fields):
                 raise Exception('unexpected dataset_description.json contents')
             description_file.seek(0)
             description_file.truncate(0)
-            description_file.write(json.dumps(updated))
+            description_file.write(json.dumps(updated, indent=4))
         ds.add(path=path, message='update dataset_description')
         return updated
     else:

--- a/tests/test_description.py
+++ b/tests/test_description.py
@@ -5,6 +5,7 @@ import json
 
 from .dataset_fixtures import *
 
+
 def test_update(celery_app, client, new_dataset):
     key = 'Name'
     value = 'Guthrum'
@@ -13,12 +14,13 @@ def test_update(celery_app, client, new_dataset):
             key: value
         }
     })
-    
+
     ds_id = os.path.basename(new_dataset.path)
     update_response = client.simulate_post(
         '/datasets/{}/description'.format(ds_id), body=body)
     assert update_response.status == falcon.HTTP_OK
-    updated_ds = json.loads(update_response.content, encoding='utf-8') if update_response.content else None
+    updated_ds = json.loads(
+        update_response.content, encoding='utf-8') if update_response.content else None
     assert updated_ds is not None
 
     check_response = client.simulate_get(
@@ -50,7 +52,8 @@ def test_update_with_trailing_newline(celery_app, client, new_dataset):
     update_response = client.simulate_post(
         '/datasets/{}/description'.format(ds_id), body=body)
     assert update_response.status == falcon.HTTP_OK
-    updated_ds = json.loads(update_response.content, encoding='utf-8') if update_response.content else None
+    updated_ds = json.loads(
+        update_response.content, encoding='utf-8') if update_response.content else None
     assert updated_ds is not None
 
     check_response = client.simulate_get(
@@ -58,3 +61,29 @@ def test_update_with_trailing_newline(celery_app, client, new_dataset):
     assert check_response.status == falcon.HTTP_OK
     ds_description = json.loads(check_response.content, encoding='utf-8')
     assert ds_description[key] == value
+
+
+def test_description_formatting(celery_app, client, new_dataset):
+    key = 'Name'
+    value = 'Guthrum'
+    body = json.dumps({
+        'description_fields': {
+            key: value
+        }
+    })
+
+    ds_id = os.path.basename(new_dataset.path)
+    update_response = client.simulate_post(
+        '/datasets/{}/description'.format(ds_id), body=body)
+    assert update_response.status == falcon.HTTP_OK
+    updated_ds = json.loads(
+        update_response.content, encoding='utf-8') if update_response.content else None
+    assert updated_ds is not None
+
+    check_response = client.simulate_get(
+        '/datasets/{}/files/dataset_description.json'.format(ds_id))
+    assert check_response.status == falcon.HTTP_OK
+    decoded_response = check_response.content.decode('utf-8')
+    # Verify the 4 space indent in the endcoded file
+    assert decoded_response[:6] == '{\n    '
+    assert decoded_response[6] != ' '


### PR DESCRIPTION
This prevents extra git churn when each formats the same file differently