### PR TITLE
Fix bug when dataset_description.json has a trailing Windows line separator

### DIFF
--- a/tests/test_description.py
+++ b/tests/test_description.py
@@ -30,8 +30,7 @@ def test_update(celery_app, client, new_dataset):
     assert ds_description[key] == value
 
 
-def test_update_with_trailing_newline(celery_app, client, new_dataset):
-    preedit_description = '{ "json stuff": "True", "Name": "Uhtred" }\n\n'
+def post_and_check_description(client, new_dataset, base_description):
     key = 'Name'
     value = 'Guthrum'
     body = json.dumps({
@@ -42,7 +41,7 @@ def test_update_with_trailing_newline(celery_app, client, new_dataset):
 
     ds_id = os.path.basename(new_dataset.path)
     update_response = client.simulate_post(
-        '/datasets/{}/files/dataset_description.json'.format(ds_id), body=preedit_description)
+        '/datasets/{}/files/dataset_description.json'.format(ds_id), body=base_description)
     assert update_response.status == falcon.HTTP_OK
     # Commit files
     response = client.simulate_post(
@@ -61,6 +60,30 @@ def test_update_with_trailing_newline(celery_app, client, new_dataset):
     assert check_response.status == falcon.HTTP_OK
     ds_description = json.loads(check_response.content, encoding='utf-8')
     assert ds_description[key] == value
+
+
+def test_update_with_trailing_newline(celery_app, client, new_dataset):
+    base_description = '{ "json stuff": "True", "Name": "Uhtred" }\n'
+    post_and_check_description(client, new_dataset, base_description)
+
+def test_update_with_trailing_double_newline(celery_app, client, new_dataset):
+    base_description = '{ "json stuff": "True", "Name": "Uhtred" }\n\n'
+    post_and_check_description(client, new_dataset, base_description)
+
+
+def test_update_with_trailing_windows_newline(celery_app, client, new_dataset):
+    base_description = '{ "json stuff": "True", "Name": "Uhtred" }\r\n'
+    post_and_check_description(client, new_dataset, base_description)
+
+
+def test_update_with_trailing_mac_newline(celery_app, client, new_dataset):
+    base_description = '{ "json stuff": "True", "Name": "Uhtred" }\r'
+    post_and_check_description(client, new_dataset, base_description)
+
+
+def test_update_with_trailing_wat_newline(celery_app, client, new_dataset):
+    base_description = '{ "json stuff": "True", "Name": "Uhtred" }\n\r'
+    post_and_check_description(client, new_dataset, base_description)
 
 
 def test_description_formatting(celery_app, client, new_dataset):


### PR DESCRIPTION
The existing implementation would eat a different number of characters if the original dataset_description.json ends with a Windows newline. This avoids changing the newline structure at all when making the state comparison and allows snapshot creation in this case.