### PR TITLE
Fix incorrect celery queue assignment for migrate to bucket task

### DIFF
--- a/datalad_service/handlers/publish.py
+++ b/datalad_service/handlers/publish.py
@@ -1,7 +1,7 @@
 import falcon
 
 from datalad_service.common.user import get_user_info
-from datalad_service.common.celery import dataset_queue
+from datalad_service.common.celery import publish_queue
 from datalad_service.tasks.dataset import *
 from datalad_service.tasks.publish import migrate_to_bucket
 
@@ -15,7 +15,7 @@ class PublishResource(object):
 
     def on_post(self, req, resp, dataset):
         datalad = self.store.get_dataset(dataset)
-        queue = dataset_queue(dataset)
+        queue = publish_queue()
         publish = migrate_to_bucket.s(self.store.annex_path, dataset, cookies=req.cookies)
         publish.apply_async(queue=queue)
         resp.media = {}
@@ -23,7 +23,7 @@ class PublishResource(object):
     
     def on_delete(self, req, resp, dataset):
         datalad = self.store.get_dataset
-        queue = dataset_queue(dataset)
+        queue = publish_queue()
         publish = migrate_to_bucket.s(self.store.annex_path, dataset, cookies=req.cookies, realm='PRIVATE')
         publish.apply_async(queue=queue)
         resp.media = {}

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -4,7 +4,7 @@ from .dataset_fixtures import *
 from datalad_service.tasks.validator import validate_dataset_sync
 
 def test_validator(new_dataset):
-    results = validate_dataset_sync(new_dataset.path)
+    results = validate_dataset_sync(new_dataset.path, 'HEAD')
     # new_dataset doesn't pass validation, should return an error
     assert 'issues' in results
     assert 'errors' in results['issues']


### PR DESCRIPTION
Only publish workers have access to remote credentials. The migrate to bucket task requires those credentials to update GitHub remotes.