### PR TITLE
68 remote configs

### DIFF
--- a/datalad_service/common/s3.py
+++ b/datalad_service/common/s3.py
@@ -41,8 +41,7 @@ class DatasetRealm(Enum):
         return 's3://{bucket}'.format(bucket=bucket)
 
 
-def setup_s3_sibling(dataset, realm):
-    """Add a sibling for an S3 bucket publish."""
+def generate_annex_options(dataset, realm):
     dataset_id = os.path.basename(dataset.path)
     annex_options = [
         'type=S3',
@@ -62,10 +61,35 @@ def setup_s3_sibling(dataset, realm):
             ]
     else:
         public = 'no'
-
     annex_options.append('public={}'.format(public))
+    return annex_options
 
+
+def setup_s3_sibling(dataset, realm):
+    """Add a sibling for an S3 bucket publish."""
+    annex_options = generate_annex_options(dataset, realm)
     dataset.repo.init_remote(realm.s3_remote, options=annex_options)
+
+
+# checks that s3-PUBLIC annex-options match those set in setup_s3_siblings
+def validate_s3_config(dataset, realm):
+    # get s3-PUBLIC annex options
+    special_remotes = dataset.repo.get_special_remotes()
+    for key, options in special_remotes.items():
+        if options.get('name') == 's3-PUBLIC':
+            s3_public_remote_options = options
+
+    expected_annex_options = generate_annex_options(dataset, realm)
+
+    # check that each of the expected annex options is set for s3_PUBLIC
+    match = True
+    for option in expected_annex_options:
+        key, expected_value = option.split('=')
+        if not s3_public_remote_options.get(key) == expected_value:
+            match = False
+            break
+
+    return match
 
 
 def s3_export(dataset, target, treeish='HEAD'):

--- a/datalad_service/common/s3.py
+++ b/datalad_service/common/s3.py
@@ -41,7 +41,7 @@ class DatasetRealm(Enum):
         return 's3://{bucket}'.format(bucket=bucket)
 
 
-def generate_annex_options(dataset, realm):
+def generate_s3_annex_options(dataset, realm):
     dataset_id = os.path.basename(dataset.path)
     annex_options = [
         'type=S3',
@@ -67,7 +67,7 @@ def generate_annex_options(dataset, realm):
 
 def setup_s3_sibling(dataset, realm):
     """Add a sibling for an S3 bucket publish."""
-    annex_options = generate_annex_options(dataset, realm)
+    annex_options = generate_s3_annex_options(dataset, realm)
     dataset.repo.init_remote(realm.s3_remote, options=annex_options)
 
 
@@ -79,7 +79,7 @@ def validate_s3_config(dataset, realm):
         if options.get('name') == 's3-PUBLIC':
             s3_public_remote_options = options
 
-    expected_annex_options = generate_annex_options(dataset, realm)
+    expected_annex_options = generate_s3_annex_options(dataset, realm)
 
     # check that each of the expected annex options is set for s3_PUBLIC
     match = True

--- a/datalad_service/common/s3.py
+++ b/datalad_service/common/s3.py
@@ -75,6 +75,7 @@ def update_s3_sibling(dataset, realm):
     """Update S3 remote with latest config."""
     annex_options = generate_s3_annex_options(dataset, realm)
 
+    # note: enableremote command will only upsert config options, none are deleted
     dataset.repo._run_annex_command('enableremote', annex_options=[realm.s3_remote] + annex_options)
     dataset.repo.config.reload()
 

--- a/datalad_service/common/s3.py
+++ b/datalad_service/common/s3.py
@@ -71,8 +71,16 @@ def setup_s3_sibling(dataset, realm):
     dataset.repo.init_remote(realm.s3_remote, options=annex_options)
 
 
-# checks that s3-PUBLIC annex-options match those set in setup_s3_siblings
+def update_s3_sibling(dataset, realm):
+    """Update S3 remote with latest config."""
+    annex_options = generate_s3_annex_options(dataset, realm)
+
+    dataset.repo._run_annex_command('enableremote', annex_options=[realm.s3_remote] + annex_options)
+    dataset.repo.config.reload()
+
+
 def validate_s3_config(dataset, realm):
+    """Checks that s3-PUBLIC annex-options match those set in setup_s3_siblings"""
     # get s3-PUBLIC annex options
     special_remotes = dataset.repo.get_special_remotes()
     for key, options in special_remotes.items():

--- a/datalad_service/tasks/publish.py
+++ b/datalad_service/tasks/publish.py
@@ -10,7 +10,7 @@ from datalad_service.config import GRAPHQL_ENDPOINT
 import datalad_service.common.s3
 from datalad_service.common.s3 import DatasetRealm, s3_export, s3_versions, get_s3_realm
 from datalad_service.common.celery import dataset_task, publish_queue
-from datalad_service.common.s3 import validate_s3_config
+from datalad_service.common.s3 import validate_s3_config, update_s3_sibling
 
 
 def create_github_repo(dataset, repo_name):
@@ -189,18 +189,9 @@ def monitor_remote_configs(store, dataset, snapshot, realm=None):
     """Check remote configs and correct invalidities."""
     ds = store.get_dataset(dataset)
     siblings = ds.siblings()
-
-    print('========================')
-    print(f'siblings: {siblings}')
-    print(f'realm: {realm}')
-
     realm = get_dataset_realm(ds, siblings, realm)
-    print(f'realm: {realm}')
 
     if realm == DatasetRealm.PUBLIC:
         s3_ok = validate_s3_config(ds, realm)
-        print(f's3 ok: {s3_ok}')
-
-    print('========================')
-
-    return { 'DOOOOOOOOOOONNNNNNNNEEEEEEEEEEEEE' }
+        if not s3_ok:
+            update_s3_sibling(ds, realm)

--- a/datalad_service/tasks/publish.py
+++ b/datalad_service/tasks/publish.py
@@ -10,6 +10,7 @@ from datalad_service.config import GRAPHQL_ENDPOINT
 import datalad_service.common.s3
 from datalad_service.common.s3 import DatasetRealm, s3_export, s3_versions, get_s3_realm
 from datalad_service.common.celery import dataset_task, publish_queue
+from datalad_service.common.s3 import validate_s3_config
 
 
 def create_github_repo(dataset, repo_name):
@@ -81,6 +82,22 @@ def publish_target(dataset, target, treeish):
         return s3_export(dataset, target, treeish)
 
 
+def get_dataset_realm(ds, siblings, realm=None):
+    # if realm parameter is not included, find the best target
+    if realm is None:
+        # if the dataset has a public sibling, use this as the export target
+        # otherwise, use the private as the export target
+        public_bucket_name = DatasetRealm(DatasetRealm.PUBLIC).s3_remote
+        has_public_bucket = get_sibling_by_name(public_bucket_name, siblings)
+        if has_public_bucket:
+            realm = DatasetRealm(DatasetRealm.PUBLIC)
+        else:
+            realm = DatasetRealm(DatasetRealm.PRIVATE)
+    else:
+        realm = get_s3_realm(realm=realm)
+    return realm
+
+
 @dataset_task
 def migrate_to_bucket(store, dataset, cookies=None, realm='PUBLIC'):
     """Migrate a dataset and all snapshots to an S3 bucket"""
@@ -110,18 +127,7 @@ def publish_snapshot(store, dataset, snapshot, cookies=None, realm=None):
     ds = store.get_dataset(dataset)
     siblings = ds.siblings()
 
-    # if realm parameter is not included, find the best target
-    if realm is None:
-        # if the dataset has a public sibling, use this as the export target
-        # otherwise, use the private as the export target
-        public_bucket_name = DatasetRealm(DatasetRealm.PUBLIC).s3_remote
-        has_public_bucket = get_sibling_by_name(public_bucket_name, siblings)
-        if has_public_bucket:
-            realm = DatasetRealm(DatasetRealm.PUBLIC)
-        else:
-            realm = DatasetRealm(DatasetRealm.PRIVATE)
-    else:
-        realm = get_s3_realm(realm=realm)
+    realm = get_dataset_realm(ds, siblings, realm)
 
     # Create the sibling if it does not exist
     s3_sibling(ds, siblings)
@@ -177,3 +183,24 @@ def file_urls_mutation(dataset_id, snapshot_tag, file_urls):
             'files': file_update
         }
     }
+
+@dataset_task
+def monitor_remote_configs(store, dataset, snapshot, realm=None):
+    """Check remote configs and correct invalidities."""
+    ds = store.get_dataset(dataset)
+    siblings = ds.siblings()
+
+    print('========================')
+    print(f'siblings: {siblings}')
+    print(f'realm: {realm}')
+
+    realm = get_dataset_realm(ds, siblings, realm)
+    print(f'realm: {realm}')
+
+    if realm == DatasetRealm.PUBLIC:
+        s3_ok = validate_s3_config(ds, realm)
+        print(f's3 ok: {s3_ok}')
+
+    print('========================')
+
+    return { 'DOOOOOOOOOOONNNNNNNNEEEEEEEEEEEEE' }


### PR DESCRIPTION
 S3 public remote options are validated against the current configuration for public datasets when a new snapshot is created.

We could move this check to trigger on something else. Thoughts?